### PR TITLE
Database warmup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,33 @@ python backtest.py
 
 Feel free to modify that file to test and compare different settings and time periods
 
+## Database warmup
+
+You can warmup your database with coins wich you might want to add later to your supported coin list. 
+This should prevent uncontrolled jumps when you add a new coin to your supported coin list.
+
+After the execution you should wait one or two trades of the bot before adding any new coin to your list.
+
+By running the script without parameters, it will warm up the bots default database with all available coins for the bridge.
+
+```shell
+pyhton3 database_warmup.py
+```
+
+If you want to specify a separate db file you can use the -d or --dbfile parameter.
+If not provided, the script will use the bots default db file.
+
+```shell
+pyhton3 database_warmup.py -d data/warmup.db
+```
+
+You can also specify the coins you want to warmup with the -c or --coinlist parameter.
+If not provided the script will warmup all coins available for the bridge.
+
+```shell
+pyhton3 database_warmup.py -c 'ADA BTC ETH LTC'
+```
+
 ## Developing
 
 To make sure your code is properly formatted before making a pull request,

--- a/binance_trade_bot/__init__.py
+++ b/binance_trade_bot/__init__.py
@@ -1,3 +1,4 @@
 from .backtest import backtest
+from .database_warmup import warmup_database
 from .binance_api_manager import BinanceAPIManager
 from .crypto_trading import main as run_trader

--- a/binance_trade_bot/database_warmup.py
+++ b/binance_trade_bot/database_warmup.py
@@ -42,7 +42,7 @@ class WarmUpDatabase(Database):
 
             # For all the symbols in the config file, add them to the database
             # if they don't exist
-            for symbol in warmup_symbols:
+            for symbol in symbols:
                 coin = next((coin for coin in coins if coin.symbol == symbol), None)
                 if coin is None:
                     session.add(Coin(symbol))
@@ -92,9 +92,14 @@ class WarmUpTrader(AutoTrader):
 
                 pair.ratio = from_coin_price / to_coin_price
 
-def warmup_database(coin_list: List[str] = None, dbPathUri ="sqlite:///data/crypto_trading.db", config: Config = None):
+def warmup_database(coin_list: List[str] = None, db_path = "data/crypto_trading.db", config: Config = None):
     logger = Logger()
     logger.info("Starting database warmup")
+
+    logger.info(f'Will be using {db_path} as database')
+    dbPathUri = f"sqlite:///{db_path}"
+
+   
 
     config = config or Config()
     db = WarmUpDatabase(logger, config, dbPathUri)
@@ -111,8 +116,10 @@ def warmup_database(coin_list: List[str] = None, dbPathUri ="sqlite:///data/cryp
     db.create_database()
     logger.info("Done creating database schema")
 
+    warmup_coin_list = coin_list or get_all_bridge_coins(manager, config)
+    logger.info(f'Going to warm up the following coins: {warmup_coin_list}')
+
     logger.info("Adding coins and pairs to database for warm up")
-    warmup_coin_list: coin_list or List[str] = get_all_bridge_coins(manager, config)
     db.set_coins_to_warmup(config.SUPPORTED_COIN_LIST, warmup_coin_list)
     logger.info("Done adding coins to warm up")
 

--- a/binance_trade_bot/database_warmup.py
+++ b/binance_trade_bot/database_warmup.py
@@ -1,0 +1,140 @@
+from typing import List
+from re import search
+
+from sqlalchemy.orm import Session, aliased
+
+from .logger import Logger
+from .config import Config
+from .database import Database
+from .binance_api_manager import BinanceAPIManager
+from .auto_trader import AutoTrader
+from .models.coin import Coin
+from .models.pair import Pair
+
+class WarmUpManager(BinanceAPIManager):
+    def get_all_symbol_tickers(self):       
+        return self.binance_client.get_symbol_ticker()
+
+class WarmUpDatabase(Database):
+    def __init__(self, logger: Logger, config: Config, uri="sqlite:///data/crypto_trading.db"):
+        super().__init__(logger, config, uri)
+
+    def set_coins_to_warmup(self, symbols: List[str], warmup_symbols: List[str]):
+        session: Session
+
+         # Add coins to the database and set them as enabled or not
+        with self.db_session() as session:
+            coins: List[Coin] = session.query(Coin).all()
+
+            # For all warmup symbols and add them to the database if they don't exist
+            for symbol in warmup_symbols:
+                coin = next((coin for coin in coins if coin.symbol == symbol), None)
+                if coin is None:
+                    newCoin = Coin(symbol, False)
+                    session.add(newCoin)
+                    coins.append(newCoin)
+
+            # For all the coins in the database, if the symbol no longer appears
+            # in the config file, set the coin as disabled
+            for coin in coins:
+                if coin.symbol not in warmup_symbols:
+                    coin.enabled = False
+
+            # For all the symbols in the config file, add them to the database
+            # if they don't exist
+            for symbol in warmup_symbols:
+                coin = next((coin for coin in coins if coin.symbol == symbol), None)
+                if coin is None:
+                    session.add(Coin(symbol))
+                else:
+                    coin.enabled = True
+
+        # For all the combinations of coins in the database, add a pair to the database
+        with self.db_session() as session:
+            c1 = aliased(Coin)
+            c2 = aliased(Coin)
+            p = aliased(Pair)
+
+            #select all pairs with non exiting pair entry in db and add the missing pair entries
+            query = session.query(c1, c2).\
+                join(c2, c2.symbol != c1.symbol).\
+                outerjoin(p, p.from_coin_id == c1.symbol and p.to_coin_id == c2.symbol).\
+                filter(p.id == None)
+
+            pairs = query.all()
+            for fromCoin, toCoin in pairs:
+                #exclude bridge coin pairs
+                if fromCoin.symbol != self.config.BRIDGE_SYMBOL and toCoin.symbol != self.config.BRIDGE_SYMBOL:
+                    session.add(Pair(fromCoin, toCoin))
+
+class WarmUpTrader(AutoTrader):
+
+    def initialize_trade_thresholds(self):
+        """
+        Initialize the buying threshold of all the coins for trading between them
+        """
+        session: Session
+        with self.db.db_session() as session:
+            for pair in session.query(Pair).filter(Pair.ratio.is_(None)).all():
+                from_coin_price = self.manager.get_ticker_price(pair.from_coin + self.config.BRIDGE)
+                if from_coin_price is None:
+                    self.logger.info(
+                        "Skipping initializing {}, symbol not found".format(pair.from_coin + self.config.BRIDGE)
+                    )
+                    continue
+
+                to_coin_price = self.manager.get_ticker_price(pair.to_coin + self.config.BRIDGE)
+                if to_coin_price is None:
+                    self.logger.info(
+                        "Skipping initializing {}, symbol not found".format(pair.to_coin + self.config.BRIDGE)
+                    )
+                    continue
+
+                pair.ratio = from_coin_price / to_coin_price
+
+def warmup_database(coin_list: List[str] = None, dbPathUri ="sqlite:///data/crypto_trading.db", config: Config = None):
+    logger = Logger()
+    logger.info("Starting database warmup")
+
+    config = config or Config()
+    db = WarmUpDatabase(logger, config, dbPathUri)
+    manager = WarmUpManager(config, db, logger)
+    # check if we can access API feature that require valid config
+    try:
+        _ = manager.get_account()
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error("Couldn't access Binance API - API keys may be wrong or lack sufficient permissions")
+        logger.error(e)
+        return
+
+    logger.info("Creating database schema if it doesn't already exist")
+    db.create_database()
+    logger.info("Done creating database schema")
+
+    logger.info("Adding coins and pairs to database for warm up")
+    warmup_coin_list: coin_list or List[str] = get_all_bridge_coins(manager, config)
+    db.set_coins_to_warmup(config.SUPPORTED_COIN_LIST, warmup_coin_list)
+    logger.info("Done adding coins to warm up")
+
+    logger.info("Starting warm up")
+    trader = WarmUpTrader(manager, db, logger, config)
+    trader.initialize_trade_thresholds()
+    logger.info("Done. Your database is now warmed up")
+    
+    manager.stream_manager.close()
+
+def get_all_bridge_coins(manager: WarmUpManager, config: Config):
+    #fetch all tickers
+    all_symbols = manager.get_all_symbol_tickers()
+
+    all_bridge_coins: List[str] = []
+    for pair in all_symbols:
+        symbol = pair["symbol"]
+        #search for coins tradeable via bridge. exlude UP DOWN BEAR BULL stuff
+        if search(f"^\w*(?<!UP){config.BRIDGE_SYMBOL}$", symbol) \
+            and search(f"^\w*(?<!DOWN){config.BRIDGE_SYMBOL}$", symbol)\
+            and search(f"^\w*(?<!BEAR){config.BRIDGE_SYMBOL}$", symbol)\
+            and search(f"^\w*(?<!BULL){config.BRIDGE_SYMBOL}$", symbol)\
+        :
+            all_bridge_coins.append(symbol.replace(config.BRIDGE_SYMBOL, ""))
+    return all_bridge_coins

--- a/database_warmup.py
+++ b/database_warmup.py
@@ -1,0 +1,8 @@
+
+import os
+
+from binance_trade_bot import warmup_database
+
+if __name__ == "__main__":
+    warmup_database()
+    os._exit(os.EX_OK)

--- a/database_warmup.py
+++ b/database_warmup.py
@@ -1,8 +1,26 @@
 
-import os
+import os, sys, getopt
 
 from binance_trade_bot import warmup_database
 
 if __name__ == "__main__":
-    warmup_database()
+    db_path = None
+    coin_list = None
+    try:
+      opts, args = getopt.getopt(sys.argv[1:],"hd:c:",["dbpath=","coinlist="])
+    except getopt.GetoptError:
+        pass
+    for opt, arg in opts:
+        if opt == '-h':
+            print('database_warmup.py - Script to farm up a db with some coins')
+            print('parameters:')
+            print('-d, --dbpath <optional, path to db, if not given the default db path will be used>')
+            print('-c, --coinlist <optional, list of coins, e.g \'ADA BTC ETH ...\', if not given all coins available for bridge will be used>')
+            os._exit(os.EX_OK)
+        elif opt in ("-d", "--dbpath"):
+            db_path = arg
+        elif opt in ("-c", "--coinlist"):
+            coin_list = arg.split()
+
+    warmup_database(coin_list, db_path)
     os._exit(os.EX_OK)

--- a/database_warmup.py
+++ b/database_warmup.py
@@ -4,7 +4,7 @@ import os, sys, getopt
 from binance_trade_bot import warmup_database
 
 if __name__ == "__main__":
-    db_path = None
+    db_path = "data/crypto_trading.db"
     coin_list = None
     try:
       opts, args = getopt.getopt(sys.argv[1:],"hd:c:",["dbpath=","coinlist="])


### PR DESCRIPTION
Hi there,

I added a script to warm up  databases with ratios of new coins.

Since the ``update_trade_threshold``-Method of the AutoTrader-Class updates ratios all (even disabled) pairs, it should be save to add new coins to the supported_coin_list after the warmup and one or two trades of the bot.  

Would appreciate any feedback.

Greetings